### PR TITLE
update: fix deployment and values yaml

### DIFF
--- a/charts/archivista/Chart.yaml
+++ b/charts/archivista/Chart.yaml
@@ -3,18 +3,15 @@ name: archivista
 description: A Helm chart for Archivista
 
 type: application
-version: 0.1.1
+version: 0.5.1
 
 keywords:
   - attestation
 
-home: https://www.testifysec.com/
 
 sources:
-  - https://github.com/testifysec/charts
   - https://github.com/in-toto/archivista
 
 maintainers:
-  - name: TestifySec
 
-appVersion: "0.1.1"
+appVersion: "0.5.4"

--- a/charts/archivista/README.md
+++ b/charts/archivista/README.md
@@ -31,13 +31,9 @@ helm uninstall archivista
 
 ## Maintainers
 
-| Name       | Email | Url                           |
-| ---        | ---   | ---                           |
-| TestifySec |       | <https://www.testifysec.com/> |
 
 ## Source Code
 
-* Helm charts: <https://github.com/testifysec/charts>
 * Archivista: <https://github.com/in-toto/archivista>
 
 ## Values

--- a/charts/archivista/templates/deployment.yaml
+++ b/charts/archivista/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- toYaml .Values.deployment.env | nindent 12 }}
+          {{- with .Values.deployment.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: graphql
               containerPort: 8082
@@ -48,3 +52,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "archivista.serviceAccountName" . }}

--- a/charts/archivista/values.yaml
+++ b/charts/archivista/values.yaml
@@ -1,10 +1,23 @@
+# Copyright 2023 The Archivista Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 replicaCount: 1
 
 image:
   repository: ghcr.io/in-toto/archivista
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.1.1"
+  tag: "0.5.3"
 
 nameOverride: ""
 fullnameOverride: ""
@@ -46,6 +59,9 @@ deployment:
   # - name: ARCHIVISTA_BLOB_STORE_BUCKET_NAME
   #   value: attestations
 
+  ## Allows the specification of a configmap or secret to set all key-value pairs as environment variables for Archivista
+  envFrom: []
+  
 service:
   type: ClusterIP
   port: 8082


### PR DESCRIPTION
This pull request does not fix any current open issue.

As https://github.com/testifysec/charts charts are references to other Helm Charts, this issue is due to the lack of synchronization from https://github.com/testifysec/charts and https://github.com/in-toto/archivista/tree/main/chart.

fix testify chart in reference to below issues:
  - https://github.com/in-toto/archivista/pull/371
  - https://github.com/in-toto/archivista/issues/326

In reference to https://github.com/in-toto/archivista/issues/412, upstream helm chart has multiple versioning issues <> incorrect helm repository (if https://github.com/in-toto/archivista/blob/charts-page is a valid branch for GH Page Helm Deployment)

Note: Although this PR syncs between upstream, chart version / tag version dont match. Could cause issue / confusion.